### PR TITLE
return rss and atom parsing libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,27 +2,45 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.10"
+name = "adler32"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+
+[[package]]
+name = "atom_syndication"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0b2fa7aedc48c4fbe1d38b25c1462a6e7b962397f27a3a8d7cbb1c08f0008b"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "diligent-date-parser",
+ "quick-xml 0.18.1",
+]
 
 [[package]]
 name = "atty"
@@ -32,7 +50,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -49,13 +67,14 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -74,15 +93,18 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "118cf036fbb97d0816e3c34b2d7a1e8cfc60f68fcf63d550ddbe9bd5f59c213b"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "b1be3409f94d7bdceeb5f5fac551039d9b3f00e25da7a74fc4d33400a0d96368"
 
 [[package]]
 name = "cfg-if"
@@ -150,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762e34611d2d5233a506a79072be944fddd057db2f18e04c0d6fa79e3fd466fd"
+checksum = "b0447a642435be046540f042950d874a4907f9fee28c0513a0beb3ba89f91eb7"
 dependencies = [
  "curl-sys",
  "libc",
@@ -160,14 +182,14 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.31+curl-7.70.0"
+version = "0.4.32+curl-7.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcd62757cc4f5ab9404bc6ca9f0ae447e729a1403948ce5106bd588ceac6a3b0"
+checksum = "834425a2f22fdd621434196965bf99fbfd9eaed96348488e27b7ac40736c560b"
 dependencies = [
  "cc",
  "libc",
@@ -176,14 +198,74 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "diesel"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d7ca63eb2efea87a7f56a283acc49e2ce4b2bd54adf7465dc1d81fef13d8fc"
+checksum = "3e2de9deab977a153492a1468d1b1c0662c1cf39e5ea87d0c060ecd59ef18d8c"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -204,6 +286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "diligent-date-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28caca0eb64b9b22bdcab47424e0f7716af92d33ad035f765e5ec2b08cf14fcc"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +304,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 name = "el_monitorro"
 version = "0.1.0"
 dependencies = [
+ "atom_syndication",
  "chrono",
  "diesel",
  "dotenv",
@@ -222,6 +314,7 @@ dependencies = [
  "futures",
  "isahc",
  "log 0.4.8",
+ "rss",
  "serde_json",
  "telegram-bot",
  "tokio",
@@ -275,7 +368,8 @@ dependencies = [
 [[package]]
 name = "feed-rs"
 version = "0.2.4"
-source = "git+https://github.com/feed-rs/feed-rs?rev=db26dffbb812def2788c77500544d1b369381ccb#db26dffbb812def2788c77500544d1b369381ccb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "285c21fd7c2ff96625b352f99120670f7bc5f4327a7262d7dda31d2a473ed4b9"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -427,6 +521,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add72f17bb81521258fcc8a7a3245b1e184e916bfbe34f0ea89558f440df5c68"
+dependencies = [
+ "cc",
+ "libc",
+ "log 0.4.8",
+ "rustc_version",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
@@ -545,6 +652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -575,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "isahc"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098c47b6176a9b667292810105999d6029d8338819f299584677e8a125e549c2"
+checksum = "f54e7cf252df9a36605ccfabea2a754ad30c24b51b77f830486e555ac8e76bce"
 dependencies = [
  "bytes",
  "crossbeam-channel",
@@ -600,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "kernel32-sys"
@@ -628,9 +741,9 @@ checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.3"
+version = "0.1.4+1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b359f5ec8106bc297694c9a562ace312be2cfd17a5fc68dc12249845aa144b11"
+checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
 dependencies = [
  "cc",
  "libc",
@@ -664,6 +777,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ecc775857611e1df29abba5c41355cdf540e7e9d4acfdf0f355eefee82330b7"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
 ]
 
 [[package]]
@@ -712,6 +836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,8 +871,8 @@ checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 dependencies = [
  "log 0.4.8",
  "mio",
- "miow 0.3.4",
- "winapi 0.3.8",
+ "miow 0.3.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -767,12 +900,12 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -814,14 +947,14 @@ checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg 1.0.0",
  "num-traits",
@@ -829,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -848,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
@@ -860,9 +993,9 @@ checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "openssl"
-version = "0.10.29"
+version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -880,9 +1013,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.57"
+version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -947,18 +1080,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -967,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
+checksum = "282adbf10f2698a7a77f8e983a74b2d18176c19a7fd32a45446139ae7b02b715"
 
 [[package]]
 name = "pin-utils"
@@ -1006,15 +1139,15 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
@@ -1026,10 +1159,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quote"
-version = "1.0.6"
+name = "quick-xml"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "fe1e430bdcf30c9fdc25053b9c459bb1a4672af4617b6c783d7d91dc17c6bbb0"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc440ee4802a86e357165021e3e255a9143724da31db1e2ea540214c96a0f82"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
 ]
@@ -1050,7 +1203,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1145,7 +1298,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1159,7 +1312,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1216,11 +1369,21 @@ checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rss"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99979205510c60f80a119dedbabd0b8426517384edf205322f8bcd51796bcef9"
+dependencies = [
+ "derive_builder",
+ "quick-xml 0.17.2",
 ]
 
 [[package]]
@@ -1230,10 +1393,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "ryu"
-version = "1.0.4"
+name = "rustc_version"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schannel"
@@ -1242,8 +1414,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 
 [[package]]
 name = "security-framework"
@@ -1269,10 +1447,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.111"
+name = "semver"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 dependencies = [
  "serde_derive",
 ]
@@ -1289,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1300,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
@@ -1350,12 +1543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
-
-[[package]]
 name = "socket2"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,14 +1551,20 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.29"
+name = "strsim"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb37da98a55b1d08529362d9cbb863be17556873df2585904ab9d2bc951291d0"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "syn"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1380,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1431,7 +1624,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1459,8 +1652,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tokio"
@@ -1483,7 +1682,7 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1529,9 +1728,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c6b59d116d218cb2d990eb06b77b64043e0268ef7323aae63d8b30ae462923"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
 dependencies = [
  "cfg-if",
  "log 0.4.8",
@@ -1595,18 +1794,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "smallvec",
+ "tinyvec",
 ]
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
@@ -1630,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "version_check"
@@ -1664,9 +1863,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1690,7 +1889,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ dotenv = "0.15.0"
 env_logger = "0.7.1"
 failure = "0.1"
 log = "0.4.0"
+rss = { version = "1.0" }
 serde_json = "1.0"
-feed-rs = { git = "https://github.com/feed-rs/feed-rs", rev = "db26dffbb812def2788c77500544d1b369381ccb" }
+feed-rs = "0.2.0"
 isahc = { version = "0.9", features = ["text-decoding"]}
+atom_syndication = "0.9"
 telegram-bot = "0.7"
 futures = "0.3"
 tokio = { version = "0.2", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,16 @@
+#![feature(proc_macro_hygiene, decl_macro)]
+
 #[macro_use]
 extern crate diesel;
 extern crate log;
 #[macro_use]
 extern crate failure;
+extern crate atom_syndication;
 extern crate dotenv;
 extern crate feed_rs;
 extern crate futures;
 extern crate isahc;
+extern crate rss;
 extern crate serde_json;
 extern crate telegram_bot;
 extern crate tokio;

--- a/src/sync/feed_sync_job.rs
+++ b/src/sync/feed_sync_job.rs
@@ -1,7 +1,9 @@
 use crate::db;
 use crate::db::{feed_items, feeds};
 use crate::models::feed::Feed;
-use crate::sync::reader::fetcher::Fetcher;
+use crate::sync::reader::atom::AtomReader;
+use crate::sync::reader::json::JsonReader;
+use crate::sync::reader::rss::RssReader;
 use crate::sync::reader::FeedReaderError;
 use crate::sync::reader::ReadFeed;
 use crate::sync::FetchedFeed;
@@ -119,10 +121,22 @@ fn set_error(
 }
 
 fn read_feed(feed: &Feed) -> Result<FetchedFeed, FeedReaderError> {
-    Fetcher {
-        url: feed.link.clone(),
+    if feed.feed_type == "rss".to_string() {
+        RssReader {
+            url: feed.link.clone(),
+        }
+        .read()
+    } else if feed.feed_type == "atom".to_string() {
+        AtomReader {
+            url: feed.link.clone(),
+        }
+        .read()
+    } else {
+        JsonReader {
+            url: feed.link.clone(),
+        }
+        .read()
     }
-    .read()
 }
 
 #[cfg(test)]

--- a/src/sync/reader/atom.rs
+++ b/src/sync/reader/atom.rs
@@ -1,0 +1,111 @@
+use crate::db;
+use crate::sync::reader;
+use crate::sync::reader::{FeedReaderError, FetchedFeed, FetchedFeedItem, ReadFeed};
+use atom_syndication::Feed as AtomFeed;
+use chrono::{DateTime, FixedOffset, Utc};
+
+pub struct AtomReader {
+    pub url: String,
+}
+
+impl ReadFeed for AtomReader {
+    fn read(&self) -> Result<FetchedFeed, FeedReaderError> {
+        let body = reader::read_url(&self.url)?;
+
+        match AtomFeed::read_from(&body[..]) {
+            Ok(atom_feed) => Ok(FetchedFeed::from(atom_feed)),
+            Err(err) => {
+                let msg = format!("{}", err);
+                Err(FeedReaderError { msg })
+            }
+        }
+    }
+}
+
+impl From<AtomFeed> for FetchedFeed {
+    fn from(feed: AtomFeed) -> Self {
+        let mut items = feed
+            .entries()
+            .into_iter()
+            .filter(|item| item.links().first().is_some())
+            .map(|item| {
+                let base_date = match item.published() {
+                    None => Some(item.updated()),
+                    _ => item.published(),
+                };
+
+                let pub_date: DateTime<Utc> = parse_time(base_date);
+
+                FetchedFeedItem {
+                    title: item.title().to_string(),
+                    description: item.summary().map(|s| s.to_string()),
+                    link: item.links().first().unwrap().href().to_string(),
+                    author: Some(
+                        item.authors()
+                            .into_iter()
+                            .map(|person| person.name.to_string())
+                            .collect::<Vec<String>>()
+                            .join(", "),
+                    ),
+                    guid: Some(item.id().to_string()),
+                    publication_date: pub_date,
+                }
+            })
+            .collect::<Vec<FetchedFeedItem>>();
+
+        items.dedup_by(|a, b| a.link == b.link && a.title == b.title);
+
+        FetchedFeed {
+            title: feed.title().to_string(),
+            link: feed.links().first().unwrap().href().to_string(),
+            description: feed
+                .subtitle()
+                .map_or_else(|| "".to_string(), |s| s.to_string()),
+            items: items,
+            feed_type: "atom".to_string(),
+        }
+    }
+}
+
+fn parse_time(pub_date: Option<&DateTime<FixedOffset>>) -> DateTime<Utc> {
+    match pub_date {
+        None => db::current_time(),
+        Some(date_time) => (*date_time).into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FetchedFeed, FetchedFeedItem};
+    use atom_syndication::Feed as AtomFeed;
+    use chrono::DateTime;
+    use std::fs;
+    use std::str::FromStr;
+
+    #[test]
+    fn it_converts_atom_feed_to_fetched_feed() {
+        let xml_feed = fs::read_to_string("./tests/support/atom_feed_example.xml").unwrap();
+        let channel = AtomFeed::from_str(&xml_feed).unwrap();
+
+        let fetched_feed: FetchedFeed = channel.into();
+
+        let expected_result = FetchedFeed {
+            title: "Example Feed".to_string(),
+            link: "http://example.org/".to_string(),
+            description: "".to_string(),
+            feed_type: "atom".to_string(),
+            items: vec![FetchedFeedItem {
+                title: "Atom-Powered Robots Run Amok".to_string(),
+                description: Some("Some text.".to_string()),
+                link: "http://example.org/2003/12/13/atom03".to_string(),
+                author: Some("".to_string()),
+                guid: Some("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a".to_string()),
+                publication_date: DateTime::parse_from_rfc3339("2003-12-13T18:30:02Z")
+                    .unwrap()
+                    .into(),
+            }],
+        };
+
+        assert_eq!(expected_result, fetched_feed);
+    }
+}

--- a/src/sync/reader/json.rs
+++ b/src/sync/reader/json.rs
@@ -1,0 +1,107 @@
+use crate::db;
+use crate::sync::reader;
+use crate::sync::reader::{FeedReaderError, FetchedFeed, FetchedFeedItem, ReadFeed};
+use chrono::{DateTime, Utc};
+use feed_rs::model::Feed;
+use feed_rs::parser;
+use serde_json::Value;
+
+pub struct JsonReader {
+    pub url: String,
+}
+
+impl ReadFeed for JsonReader {
+    fn read(&self) -> Result<FetchedFeed, FeedReaderError> {
+        let body = reader::read_url(&self.url)?;
+
+        match serde_json::from_slice::<Value>(&body[..]) {
+            Ok(_) => (),
+            Err(err) => {
+                let msg = format!("{:?}", err);
+                return Err(FeedReaderError { msg });
+            }
+        }
+
+        match parser::parse(&body[..]) {
+            Ok(feed) => {
+                let mut fetched_feed = FetchedFeed::from(feed);
+                fetched_feed.link = self.url.clone();
+
+                Ok(fetched_feed)
+            }
+            Err(err) => {
+                let msg = format!("{:?}", err);
+                Err(FeedReaderError { msg })
+            }
+        }
+    }
+}
+
+impl From<Feed> for FetchedFeed {
+    fn from(feed: Feed) -> Self {
+        let mut items = feed
+            .entries
+            .into_iter()
+            .filter(|item| !item.links.is_empty())
+            .map(|item| {
+                let pub_date: DateTime<Utc> = parse_time(item.published, item.updated);
+                FetchedFeedItem {
+                    title: item.title.map_or_else(|| "".to_string(), |s| s.content),
+                    description: item.summary.map(|s| s.content),
+                    link: item.links.first().unwrap().href.clone(),
+                    author: Some(
+                        item.authors
+                            .into_iter()
+                            .map(|person| person.name)
+                            .collect::<Vec<String>>()
+                            .join(", "),
+                    ),
+                    guid: Some(item.id),
+                    publication_date: pub_date,
+                }
+            })
+            .collect::<Vec<FetchedFeedItem>>();
+
+        items.dedup_by(|a, b| a.link == b.link && a.title == b.title);
+
+        FetchedFeed {
+            title: feed.title.map_or_else(|| "".to_string(), |s| s.content),
+            description: feed
+                .description
+                .map_or_else(|| "".to_string(), |s| s.content),
+            feed_type: "json".to_string(),
+            link: "".to_string(),
+            items: items,
+        }
+    }
+}
+
+fn parse_time(pub_date: Option<DateTime<Utc>>, updated: Option<DateTime<Utc>>) -> DateTime<Utc> {
+    match pub_date {
+        None => match updated {
+            Some(value) => value,
+            None => db::current_time(),
+        },
+        Some(value) => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FetchedFeed, FetchedFeedItem};
+    use chrono::DateTime;
+    use feed_rs::parser;
+    use std::fs;
+
+    #[test]
+    fn it_converts_json_feed_to_fetched_feed() {
+        let json_feed = fs::read_to_string("./tests/support/json_feed_example.json").unwrap();
+        let feed = parser::parse(json_feed.as_bytes()).unwrap();
+
+        let fetched_feed: FetchedFeed = feed.into();
+
+        let expected_result = FetchedFeed { title: "World".to_string(), link: "".to_string(), description: "NPR world news, international art and culture, world business and financial markets, world economy, and global trends in health, science and technology. Subscribe to the World Story of the Day podcast and RSS feed.".to_string(), feed_type: "json".to_string(), items: vec![FetchedFeedItem { title: "Trump Says U.S. Will Withdraw From WHO. Does He Have The Authority To Do It?".to_string(), description: Some("In a press conference on Friday, the president said he would immediately sever ties — and funding — to the World Health Organization because of its relationship with China.".to_string()), link: "https://www.npr.org/sections/goatsandsoda/2020/05/29/865816855/trump-says-u-s-will-withdraw-from-who-does-he-have-the-authority-to-do-it?utm_medium=JSONFeed&utm_campaign=world".to_string(), author: Some("Pien Huang".to_string()), guid: Some("865816855".to_string()), publication_date: DateTime::parse_from_rfc3339("2020-05-29T23:30:03Z").unwrap().into() }, FetchedFeedItem { title: "France Eases Some Pandemic Restrictions And Will Reopen Restaurants, Bars And Parks".to_string(), description: Some("\"It will be so nice to be able to go lie on the grass in a park and have a picnic or to sit at a sidewalk cafe again,\" says a Paris resident. Restaurants and bars will reopen with restrictions June 2.".to_string()), link: "https://www.npr.org/sections/coronavirus-live-updates/2020/05/29/864892887/france-eases-some-pandemic-restrictions-and-will-reopen-restaurants-bars-and-par?utm_medium=JSONFeed&utm_campaign=world".to_string(), author: Some("Eleanor Beardsley".to_string()), guid: Some("864892887".to_string()), publication_date: DateTime::parse_from_rfc3339("2020-05-29T20:00:34Z").unwrap().into() }, FetchedFeedItem { title: "Moscow Doubles Last Month\'s Coronavirus Death Toll Amid Suspicions Of Undercounting".to_string(), description: Some("Media reports and analysts have questioned the accuracy of Russia\'s mortality figures for the virus. Moscow\'s Health Department now says 1,561 people died in April due to the coronavirus.".to_string()), link: "https://www.npr.org/sections/coronavirus-live-updates/2020/05/29/865044503/moscow-doubles-last-months-coronavirus-death-toll-amid-suspicions-of-undercounti?utm_medium=JSONFeed&utm_campaign=world".to_string(), author: Some("Jason Slotkin".to_string()), guid: Some("865044503".to_string()), publication_date: DateTime::parse_from_rfc3339("2020-05-29T19:35:00Z").unwrap().into() }] };
+
+        assert_eq!(expected_result, fetched_feed);
+    }
+}

--- a/src/sync/reader/mod.rs
+++ b/src/sync/reader/mod.rs
@@ -1,10 +1,15 @@
-use self::fetcher::Fetcher;
+use self::atom::AtomReader;
+use self::json::JsonReader;
+use self::rss::RssReader;
 use chrono::{DateTime, Utc};
 use isahc::config::RedirectPolicy;
 use isahc::prelude::*;
+use std::io;
 use std::time::Duration;
 
-pub mod fetcher;
+pub mod atom;
+pub mod json;
+pub mod rss;
 
 #[derive(Debug)]
 pub struct FeedReaderError {
@@ -50,14 +55,17 @@ pub fn read_url(url: &str) -> Result<Vec<u8>, FeedReaderError> {
     };
 
     match client.get(url) {
-        Ok(mut response) => match response.text() {
-            Ok(text) => Ok(text.as_bytes().to_vec()),
-            Err(error) => {
-                let msg = format!("{:?}", error);
+        Ok(mut response) => {
+            let mut writer: Vec<u8> = vec![];
 
-                Err(FeedReaderError { msg })
+            if let Err(err) = io::copy(response.body_mut(), &mut writer) {
+                let msg = format!("{:?}", err);
+
+                return Err(FeedReaderError { msg });
             }
-        },
+
+            Ok(writer)
+        }
         Err(error) => {
             let msg = format!("{:?}", error);
 
@@ -67,12 +75,28 @@ pub fn read_url(url: &str) -> Result<Vec<u8>, FeedReaderError> {
 }
 
 pub fn validate_rss_url(url: &str) -> Result<String, FeedReaderError> {
-    let json_reader = Fetcher {
+    let rss_reader = RssReader {
         url: url.to_string(),
     };
 
-    if let Ok(feed) = json_reader.read() {
-        return Ok(feed.feed_type);
+    if let Ok(_) = rss_reader.read() {
+        return Ok("rss".to_string());
+    }
+
+    let atom_reader = AtomReader {
+        url: url.to_string(),
+    };
+
+    if let Ok(_) = atom_reader.read() {
+        return Ok("atom".to_string());
+    }
+
+    let json_reader = JsonReader {
+        url: url.to_string(),
+    };
+
+    if let Ok(_) = json_reader.read() {
+        return Ok("json".to_string());
     }
 
     Err(FeedReaderError {

--- a/src/sync/reader/rss.rs
+++ b/src/sync/reader/rss.rs
@@ -1,0 +1,84 @@
+use crate::db;
+use crate::sync::reader;
+use crate::sync::reader::{FeedReaderError, FetchedFeed, FetchedFeedItem, ReadFeed};
+use chrono::{DateTime, Utc};
+use rss::Channel;
+
+pub struct RssReader {
+    pub url: String,
+}
+
+impl ReadFeed for RssReader {
+    fn read(&self) -> Result<FetchedFeed, FeedReaderError> {
+        let body = reader::read_url(&self.url)?;
+
+        match Channel::read_from(&body[..]) {
+            Ok(channel) => Ok(FetchedFeed::from(channel)),
+            Err(err) => {
+                let msg = format!("{}", err);
+                Err(FeedReaderError { msg })
+            }
+        }
+    }
+}
+
+impl From<Channel> for FetchedFeed {
+    fn from(channel: Channel) -> Self {
+        let mut items = channel
+            .items()
+            .into_iter()
+            .filter(|item| item.link().is_some())
+            .map(|item| {
+                let pub_date: DateTime<Utc> = parse_time(item.pub_date());
+                FetchedFeedItem {
+                    title: item
+                        .title()
+                        .map_or_else(|| "".to_string(), |s| s.to_string()),
+                    description: item.description().map(|s| s.to_string()),
+                    link: item.link().unwrap().to_string(),
+                    author: item.author().map(|s| s.to_string()),
+                    guid: item.guid().map(|s| s.value().to_string()),
+                    publication_date: pub_date,
+                }
+            })
+            .collect::<Vec<FetchedFeedItem>>();
+
+        items.dedup_by(|a, b| a.link == b.link && a.title == b.title);
+
+        FetchedFeed {
+            title: channel.title().to_string(),
+            link: channel.link().to_string(),
+            description: channel.description().to_string(),
+            feed_type: "rss".to_string(),
+            items: items,
+        }
+    }
+}
+
+fn parse_time(pub_date: Option<&str>) -> DateTime<Utc> {
+    match pub_date {
+        None => db::current_time(),
+        Some(string) => match DateTime::parse_from_rfc2822(string) {
+            Ok(date) => date.into(),
+            Err(_) => db::current_time(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FetchedFeed;
+    use rss::Channel;
+    use std::fs;
+    use std::str::FromStr;
+
+    #[test]
+    fn it_converts_rss_channel_to_fetched_feed() {
+        let xml_feed = fs::read_to_string("./tests/support/rss_feed_example.xml").unwrap();
+        let channel = Channel::from_str(&xml_feed).unwrap();
+
+        let fetched_feed: FetchedFeed = channel.into();
+
+        assert_eq!(fetched_feed.title, "FeedForAll Sample Feed".to_string());
+    }
+}

--- a/tests/support/rss_feed_example.xml
+++ b/tests/support/rss_feed_example.xml
@@ -63,5 +63,89 @@ Job Postings &lt;/i&gt;&lt;/font&gt;</description>
       <comments>http://www.feedforall.com/forum</comments>
       <pubDate>Tue, 19 Oct 2004 11:09:07 -0400</pubDate>
     </item>
+    <item>
+      <title>RSS Solutions for Governments</title>
+      <description>FeedForAll helps Governments communicate with the general public about positions on various issues, and keep the community aware of changes in important legislative issues. &lt;b&gt;&lt;i&gt;&lt;br&gt;
+&lt;/b&gt;&lt;/i&gt;&lt;br&gt;
+RSS uses Include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#00FF00&quot;&gt;Legislative Calendar&lt;br&gt;
+Votes&lt;br&gt;
+Bulletins&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/government.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:05 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Politicians</title>
+      <description>FeedForAll helps Politicians communicate with the general public about positions on various issues, and keep the community notified of their schedule. &lt;br&gt;
+&lt;br&gt;
+Uses Include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#FF0000&quot;&gt;Blogs&lt;br&gt;
+Speaking Engagements &lt;br&gt;
+Statements&lt;br&gt;
+ &lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/politics.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:03 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Meteorologists</title>
+      <description>FeedForAll helps Meteorologists communicate with the general public about storm warnings and weather alerts, in specific regions. Using RSS meteorologists are able to quickly disseminate urgent and life threatening weather warnings. &lt;br&gt;
+&lt;br&gt;
+Uses Include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Weather Alerts&lt;br&gt;
+Plotting Storms&lt;br&gt;
+School Cancellations &lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/weather.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:09:01 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Realtors &amp; Real Estate Firms</title>
+      <description>FeedForAll helps Realtors and Real Estate companies communicate with clients informing them of newly available properties, and open house announcements. RSS helps to reach a targeted audience and spread the word in an inexpensive, professional manner. &lt;font color=&quot;#0000FF&quot;&gt;&lt;br&gt;
+&lt;/font&gt;&lt;br&gt;
+Feeds can be used for:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#FF0000&quot;&gt;Open House Dates&lt;br&gt;
+New Properties For Sale&lt;br&gt;
+Mortgage Rates&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/real-estate.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:08:59 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Banks / Mortgage Companies</title>
+      <description>FeedForAll helps &lt;b&gt;Banks, Credit Unions and Mortgage companies&lt;/b&gt; communicate with the general public about rate changes in a prompt and professional manner. &lt;br&gt;
+&lt;br&gt;
+Uses include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Mortgage Rates&lt;br&gt;
+Foreign Exchange Rates &lt;br&gt;
+Bank Rates&lt;br&gt;
+Specials&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/banks.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:08:57 -0400</pubDate>
+    </item>
+    <item>
+      <title>RSS Solutions for Law Enforcement</title>
+      <description>&lt;b&gt;FeedForAll&lt;/b&gt; helps Law Enforcement Professionals communicate with the general public and other agencies in a prompt and efficient manner. Using RSS police are able to quickly disseminate urgent and life threatening information. &lt;br&gt;
+&lt;br&gt;
+Uses include:&lt;br&gt;
+&lt;i&gt;&lt;font color=&quot;#0000FF&quot;&gt;Amber Alerts&lt;br&gt;
+Sex Offender Community Notification &lt;br&gt;
+Weather Alerts &lt;br&gt;
+Scheduling &lt;br&gt;
+Security Alerts &lt;br&gt;
+Police Report &lt;br&gt;
+Meetings&lt;/i&gt;&lt;/font&gt;</description>
+      <link>http://www.feedforall.com/law-enforcement.htm</link>
+      <category domain="www.dmoz.com">Computers/Software/Internet/Site Management/Content Management</category>
+      <comments>http://www.feedforall.com/forum</comments>
+      <pubDate>Tue, 19 Oct 2004 11:08:56 -0400</pubDate>
+    </item>
   </channel>
 </rss>


### PR DESCRIPTION
In this commit https://github.com/ayrat555/el_monitorro/commit/1ac92cd62af67a7d7c88e5bed17a67fa6a3ae4fa I migrated all feed parsing to feed-rs. Unfortunately, feed-rs can not parse non-utf bytes. I'm returning rss and atom libs

Fixes https://github.com/ayrat555/el_monitorro/issues/28