### PR TITLE
limit description to 1500

### DIFF
--- a/src/bot/deliver_job.rs
+++ b/src/bot/deliver_job.rs
@@ -30,7 +30,7 @@ static TELEGRAM_ERRORS: [&'static str; 10] = [
     "Bad Request: have no rights to send a message",
 ];
 
-static DISCRIPTION_LIMIT: usize = 3500;
+static DISCRIPTION_LIMIT: usize = 1500;
 
 pub struct DeliverJob {}
 


### PR DESCRIPTION
Some message are not sent because of
`Bad Request: message is too long` error