### PR TITLE
Allow docker to run all commands at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All configuration is done through env variables
 The image is published on docker hub under [ayratbadykov/el_monitorro](https://hub.docker.com/r/ayratbadykov/el_monitorro). It accepts additional env variables:
 
 - `RUN_MIGRATION` - if this variable is not empty, `diesel database setup` is run. It creates DB and runs migrations.
-- `BOT_BINARY` - depending on this variable, docker container will run one of four binaries. Possible values are `commands`, `sync`, `deliver`, `cleaner`.
+- `BOT_BINARY` - depending on this variable, docker container will run one of four binaries. Possible values are `commands`, `sync`, `deliver`, `cleaner`, `all`.
 
 You'll have to set these variables in the `.env` file. For example:
 
@@ -152,7 +152,7 @@ docker run --env-file ./.env --network host -t ayratbadykov/el_monitorro:latest
 Notes:
 
 - `--network host` is used so the docker container can access a host network if you're running Postgres on the same machine
-- To run all binaries (commands, sync, deliver and cleaner), you'll have to start 4 containers replacing `BOT_BINARY` variable.
+- To run all binaries (commands, sync, deliver and cleaner), you'll have to start 4 containers replacing `BOT_BINARY` variable, or run with `BOT_BINARY` set to `all`.
 
 #### Creating a docker image from the latest master branch
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ docker run --env-file ./.env --network host -t ayratbadykov/el_monitorro:latest
 Notes:
 
 - `--network host` is used so the docker container can access a host network if you're running Postgres on the same machine
-- To run all binaries (commands, sync, deliver and cleaner), you'll have to start 4 containers replacing `BOT_BINARY` variable, or run with `BOT_BINARY` set to `all`.
+- To run all binaries (commands, sync, deliver and cleaner), you'll have to start 4 containers replacing `BOT_BINARY` variable, or run with `BOT_BINARY` set to `all`. If you choose to use the `all` option, it would be wise to set a cron job to restart the container periodically in case one of the executables crashes.
 
 #### Creating a docker image from the latest master branch
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -23,6 +23,9 @@ case "$BOT_BINARY" in
     cleaner*)
         ./cleaner
         ;;
+    all*)
+        ./el_monitorro & ./sync & ./deliver & ./cleaner
+        ;;
     *)
         echo "Unknown binary"
         exit 1


### PR DESCRIPTION
I know it's not Docker "best practice" to have multiple things running in a docker container at once, but I don't want to have to run multiple docker containers of the same thing on my Unraid box.