### PR TITLE
Remove empty unicode characters from messages

### DIFF
--- a/src/bot/api.rs
+++ b/src/bot/api.rs
@@ -134,7 +134,11 @@ pub fn send_message_sync(chat_id: i64, message: String) -> Result<(), Error> {
     match api.send_message(&send_message_params) {
         Ok(_) => Ok(()),
         Err(err) => {
-            log::error!("Failed to send message: {:?}", err);
+            log::error!(
+                "Failed to send message {:?}: {:?}",
+                err,
+                send_message_params
+            );
             Err(err)
         }
     }
@@ -155,7 +159,11 @@ fn reply_to_message(api: Api, message: Message, text: String) -> Result<(), Erro
     match api.send_message(&send_message_params) {
         Ok(_) => Ok(()),
         Err(err) => {
-            log::error!("Failed to send message: {:?}", err);
+            log::error!(
+                "Failed to send message message {:?}: {:?}",
+                err,
+                send_message_params
+            );
             Err(err)
         }
     }

--- a/src/bot/deliver_job.rs
+++ b/src/bot/deliver_job.rs
@@ -390,7 +390,7 @@ fn truncate_and_check(s: &str, max_chars: usize) -> String {
     if truncated_result.is_empty() {
         "According to your template the message is empty. Telegram doesn't support empty messages. That's why we're sending this placeholder message.".to_string()
     } else {
-        truncated_result.to_string()
+        truncated_result
     }
 }
 


### PR DESCRIPTION
fixes
```
 ERROR el_monitorro::bot::api] Failed to send message ApiError(ErrorResponse { ok: false, description: "Bad Request: message must be non-empty", error_code: 400 }): SendMessageParams { text: "\u{200b}", parse_mode: None, entities: None, disable_web_page_preview: None, disable_notification: None, reply_to_message_id: None, allow_sending_without_reply: None, reply_markup: None }
Aug 04 17:08:03 vps695005 bash[8432]: [2021-08-04T15:08:03Z ERROR el_monitorro::bot:
```