### PR TITLE
Add content_hash to feed_items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -165,6 +174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +190,15 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -186,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
+checksum = "7de97b894edd5b5bcceef8b78d7da9b75b1d2f2f9a910569d0bde3dd31d84939"
 dependencies = [
  "curl-sys",
  "libc",
@@ -201,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.51+curl-7.80.0"
+version = "0.4.52+curl-7.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
+checksum = "14b8c2d1023ea5fded5b7b892e4b8e95f70038a421126a056761a84246a28971"
 dependencies = [
  "cc",
  "libc",
@@ -332,7 +359,18 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer 0.10.0",
+ "crypto-common",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -363,6 +401,7 @@ dependencies = [
  "feed-rs",
  "frankenstein",
  "handlebars",
+ "hex",
  "html2text",
  "htmlescape",
  "isahc",
@@ -372,6 +411,7 @@ dependencies = [
  "rss",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "url",
 ]
@@ -537,6 +577,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.1.6"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167fa173496c9eadd8749cca6f8339ac88e248f3ad2442791d0b743318a94fc0"
+checksum = "2483bce82dd3ed52509d0117e4a30a488bd608be250ed7a0185301314239ed31"
 dependencies = [
  "log",
  "pest",
@@ -597,6 +647,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "html2text"
@@ -1394,10 +1450,21 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -1482,9 +1549,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1724,6 +1791,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ fang = "0.5"
 feed-rs = "1"
 frankenstein = { version = "0.9", default-features = false }
 handlebars = "4"
+hex = "0.4"
 html2text = "0.2"
 htmlescape = "0.3"
 isahc = "1"
@@ -24,9 +25,9 @@ regex = { version = "1", features = ["pattern"] }
 rss = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 url = "2"
-
 
 [dev-dependencies]
 mockito = "0.30"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 
-
-if [ -z "$RUN_MIGRATION" ]
+if [ -z "$SETUP_DB" ]
 then
     echo "Proceeding without setting the database"
 else
@@ -9,6 +8,13 @@ else
     ./diesel database setup
 fi
 
+if [ -z "$RUN_MIGRATION" ]
+then
+    echo "Proceeding without running migrations"
+else
+    echo "Setting the database"
+    ./diesel migration run
+fi
 
 case "$BOT_BINARY" in
     commands*)

--- a/migrations/2022-01-07-134849_add_feed_items_content_hash/down.sql
+++ b/migrations/2022-01-07-134849_add_feed_items_content_hash/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feed_items DROP COLUMN content_hash;

--- a/migrations/2022-01-07-134849_add_feed_items_content_hash/up.sql
+++ b/migrations/2022-01-07-134849_add_feed_items_content_hash/up.sql
@@ -1,1 +1,1 @@
-ALTER TABLE feed_items ADD COLUMN content_hash VARCHAR(10) NOT NULL GENERATED ALWAYS AS (encode(sha256((link || title || description)::bytea), 'hex')) STORED;
+ALTER TABLE feed_items ADD COLUMN content_hash CHAR(64);

--- a/migrations/2022-01-07-134849_add_feed_items_content_hash/up.sql
+++ b/migrations/2022-01-07-134849_add_feed_items_content_hash/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feed_items ADD COLUMN content_hash VARCHAR(10) NOT NULL GENERATED ALWAYS AS (encode(sha256((link || title || description)::bytea), 'hex')) STORED;

--- a/src/db/feed_items.rs
+++ b/src/db/feed_items.rs
@@ -2,7 +2,6 @@ use crate::models::feed_item::FeedItem;
 use crate::schema::feed_items;
 use crate::sync::FetchedFeedItem;
 use chrono::{DateTime, Utc};
-use diesel::pg::upsert::excluded;
 use diesel::result::Error;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use html2text::from_read;
@@ -49,8 +48,7 @@ pub fn create(
     diesel::insert_into(feed_items::table)
         .values(new_feed_items)
         .on_conflict((feed_items::feed_id, feed_items::title, feed_items::link))
-        .do_update()
-        .set(feed_items::content_hash.eq(excluded(feed_items::content_hash)))
+        .do_nothing()
         .get_results(conn)
 }
 
@@ -181,49 +179,49 @@ mod tests {
         });
     }
 
-    // #[test]
-    // fn create_does_not_update_existing_feed_items() {
-    //     let connection = db::establish_test_connection();
+    #[test]
+    fn create_does_not_update_existing_feed_items() {
+        let connection = db::establish_test_connection();
 
-    //     connection.test_transaction::<_, Error, _>(|| {
-    //         let feed = feeds::create(&connection, "Link".to_string(), "atom".to_string()).unwrap();
-    //         let publication_date = db::current_time();
-    //         let feed_items = vec![FetchedFeedItem {
-    //             title: "FeedItem1".to_string(),
-    //             description: Some("Description1".to_string()),
-    //             link: "Link1".to_string(),
-    //             author: Some("Author1".to_string()),
-    //             guid: Some("Guid1".to_string()),
-    //             publication_date,
-    //         }];
+        connection.test_transaction::<_, Error, _>(|| {
+            let feed = feeds::create(&connection, "Link".to_string(), "atom".to_string()).unwrap();
+            let publication_date = db::current_time();
+            let feed_items = vec![FetchedFeedItem {
+                title: "FeedItem1".to_string(),
+                description: Some("Description1".to_string()),
+                link: "Link1".to_string(),
+                author: Some("Author1".to_string()),
+                guid: Some("Guid1".to_string()),
+                publication_date,
+            }];
 
-    //         let old_result = super::create(&connection, feed.id, feed_items.clone()).unwrap();
-    //         let old_item = old_result
-    //             .iter()
-    //             .find(|item| item.guid == Some("Guid1".to_string()))
-    //             .unwrap();
+            let old_result = super::create(&connection, feed.id, feed_items.clone()).unwrap();
+            let old_item = old_result
+                .iter()
+                .find(|item| item.guid == Some("Guid1".to_string()))
+                .unwrap();
 
-    //         assert_eq!(old_item.feed_id, feed.id);
-    //         assert_eq!(old_item.title, feed_items[0].title);
-    //         assert_eq!(old_item.description, feed_items[0].description);
-    //         assert_eq!(old_item.link, feed_items[0].link);
+            assert_eq!(old_item.feed_id, feed.id);
+            assert_eq!(old_item.title, feed_items[0].title);
+            assert_eq!(old_item.description, feed_items[0].description);
+            assert_eq!(old_item.link, feed_items[0].link);
 
-    //         let updated_feed_items = vec![FetchedFeedItem {
-    //             title: "FeedItem1".to_string(),
-    //             description: Some("Description1".to_string()),
-    //             link: "Link1".to_string(),
-    //             author: Some("Author2".to_string()),
-    //             guid: Some("Guid2".to_string()),
-    //             publication_date,
-    //         }];
+            let updated_feed_items = vec![FetchedFeedItem {
+                title: "FeedItem1".to_string(),
+                description: Some("Description1".to_string()),
+                link: "Link1".to_string(),
+                author: Some("Author2".to_string()),
+                guid: Some("Guid2".to_string()),
+                publication_date,
+            }];
 
-    //         let new_result = super::create(&connection, feed.id, updated_feed_items).unwrap();
+            let new_result = super::create(&connection, feed.id, updated_feed_items).unwrap();
 
-    //         assert!(new_result.is_empty());
+            assert!(new_result.is_empty());
 
-    //         Ok(())
-    //     });
-    // }
+            Ok(())
+        });
+    }
 
     #[test]
     fn delete_old_feed_items() {

--- a/src/db/feed_items.rs
+++ b/src/db/feed_items.rs
@@ -2,9 +2,11 @@ use crate::models::feed_item::FeedItem;
 use crate::schema::feed_items;
 use crate::sync::FetchedFeedItem;
 use chrono::{DateTime, Utc};
+use diesel::pg::upsert::excluded;
 use diesel::result::Error;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl};
 use html2text::from_read;
+use sha2::{Digest, Sha256};
 
 #[derive(Insertable, AsChangeset)]
 #[table_name = "feed_items"]
@@ -16,6 +18,7 @@ pub struct NewFeedItem {
     pub author: Option<String>,
     pub guid: Option<String>,
     pub publication_date: DateTime<Utc>,
+    pub content_hash: String,
 }
 
 pub fn create(
@@ -25,23 +28,29 @@ pub fn create(
 ) -> Result<Vec<FeedItem>, Error> {
     let new_feed_items = fetched_items
         .into_iter()
-        .map(|fetched_feed_item| NewFeedItem {
-            feed_id,
-            title: from_read(fetched_feed_item.title.as_bytes(), 500)
-                .trim()
-                .to_string(),
-            description: fetched_feed_item.description,
-            link: fetched_feed_item.link,
-            author: fetched_feed_item.author,
-            guid: fetched_feed_item.guid,
-            publication_date: fetched_feed_item.publication_date,
+        .map(|fetched_feed_item| {
+            let hash = calculate_content_hash(&fetched_feed_item);
+
+            NewFeedItem {
+                feed_id,
+                title: from_read(fetched_feed_item.title.as_bytes(), 500)
+                    .trim()
+                    .to_string(),
+                description: fetched_feed_item.description,
+                link: fetched_feed_item.link,
+                author: fetched_feed_item.author,
+                guid: fetched_feed_item.guid,
+                publication_date: fetched_feed_item.publication_date,
+                content_hash: hash,
+            }
         })
         .collect::<Vec<NewFeedItem>>();
 
     diesel::insert_into(feed_items::table)
         .values(new_feed_items)
         .on_conflict((feed_items::feed_id, feed_items::title, feed_items::link))
-        .do_nothing()
+        .do_update()
+        .set(feed_items::content_hash.eq(excluded(feed_items::content_hash)))
         .get_results(conn)
 }
 
@@ -87,6 +96,18 @@ pub fn delete_old_feed_items(
         }
         Err(error) => Err(error),
     }
+}
+
+fn calculate_content_hash(fetched_feed_item: &FetchedFeedItem) -> String {
+    let mut content_hash: String = "".to_string();
+    content_hash.push_str(&fetched_feed_item.link);
+    content_hash.push_str(&fetched_feed_item.title);
+
+    let mut hasher = Sha256::new();
+    hasher.update(content_hash.as_bytes());
+
+    let result = hasher.finalize();
+    hex::encode(result)
 }
 
 pub fn get_latest_item(conn: &PgConnection, feed_id: i64) -> Option<FeedItem> {
@@ -160,49 +181,49 @@ mod tests {
         });
     }
 
-    #[test]
-    fn create_does_not_update_existing_feed_items() {
-        let connection = db::establish_test_connection();
+    // #[test]
+    // fn create_does_not_update_existing_feed_items() {
+    //     let connection = db::establish_test_connection();
 
-        connection.test_transaction::<_, Error, _>(|| {
-            let feed = feeds::create(&connection, "Link".to_string(), "atom".to_string()).unwrap();
-            let publication_date = db::current_time();
-            let feed_items = vec![FetchedFeedItem {
-                title: "FeedItem1".to_string(),
-                description: Some("Description1".to_string()),
-                link: "Link1".to_string(),
-                author: Some("Author1".to_string()),
-                guid: Some("Guid1".to_string()),
-                publication_date,
-            }];
+    //     connection.test_transaction::<_, Error, _>(|| {
+    //         let feed = feeds::create(&connection, "Link".to_string(), "atom".to_string()).unwrap();
+    //         let publication_date = db::current_time();
+    //         let feed_items = vec![FetchedFeedItem {
+    //             title: "FeedItem1".to_string(),
+    //             description: Some("Description1".to_string()),
+    //             link: "Link1".to_string(),
+    //             author: Some("Author1".to_string()),
+    //             guid: Some("Guid1".to_string()),
+    //             publication_date,
+    //         }];
 
-            let old_result = super::create(&connection, feed.id, feed_items.clone()).unwrap();
-            let old_item = old_result
-                .iter()
-                .find(|item| item.guid == Some("Guid1".to_string()))
-                .unwrap();
+    //         let old_result = super::create(&connection, feed.id, feed_items.clone()).unwrap();
+    //         let old_item = old_result
+    //             .iter()
+    //             .find(|item| item.guid == Some("Guid1".to_string()))
+    //             .unwrap();
 
-            assert_eq!(old_item.feed_id, feed.id);
-            assert_eq!(old_item.title, feed_items[0].title);
-            assert_eq!(old_item.description, feed_items[0].description);
-            assert_eq!(old_item.link, feed_items[0].link);
+    //         assert_eq!(old_item.feed_id, feed.id);
+    //         assert_eq!(old_item.title, feed_items[0].title);
+    //         assert_eq!(old_item.description, feed_items[0].description);
+    //         assert_eq!(old_item.link, feed_items[0].link);
 
-            let updated_feed_items = vec![FetchedFeedItem {
-                title: "FeedItem1".to_string(),
-                description: Some("Description1".to_string()),
-                link: "Link1".to_string(),
-                author: Some("Author2".to_string()),
-                guid: Some("Guid2".to_string()),
-                publication_date,
-            }];
+    //         let updated_feed_items = vec![FetchedFeedItem {
+    //             title: "FeedItem1".to_string(),
+    //             description: Some("Description1".to_string()),
+    //             link: "Link1".to_string(),
+    //             author: Some("Author2".to_string()),
+    //             guid: Some("Guid2".to_string()),
+    //             publication_date,
+    //         }];
 
-            let new_result = super::create(&connection, feed.id, updated_feed_items).unwrap();
+    //         let new_result = super::create(&connection, feed.id, updated_feed_items).unwrap();
 
-            assert!(new_result.is_empty());
+    //         assert!(new_result.is_empty());
 
-            Ok(())
-        });
-    }
+    //         Ok(())
+    //     });
+    // }
 
     #[test]
     fn delete_old_feed_items() {

--- a/src/deliver/deliver_chat_updates_job.rs
+++ b/src/deliver/deliver_chat_updates_job.rs
@@ -462,6 +462,7 @@ mod tests {
             link: "dsd".to_string(),
             author: None,
             guid: None,
+            content_hash: None,
             created_at: publication_date,
             updated_at: db::current_time(),
         }];
@@ -504,6 +505,7 @@ mod tests {
             link: "dsd".to_string(),
             author: None,
             guid: None,
+            content_hash: None,
             created_at: current_time,
             updated_at: current_time,
         }];
@@ -547,6 +549,7 @@ mod tests {
             link: "".to_string(),
             author: None,
             guid: None,
+            content_hash: None,
             created_at: current_time,
             updated_at: current_time,
         }];

--- a/src/models/feed_item.rs
+++ b/src/models/feed_item.rs
@@ -12,4 +12,6 @@ pub struct FeedItem {
     pub publication_date: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+
+    pub content_hash: Option<String>,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -9,6 +9,7 @@ table! {
         publication_date -> Timestamptz,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
+        content_hash -> Varchar,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -9,7 +9,7 @@ table! {
         publication_date -> Timestamptz,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
-        content_hash -> Varchar,
+        content_hash -> Nullable<Bpchar>,
     }
 }
 


### PR DESCRIPTION
Currently, for `feed_items` (feed_id, link, title) are used as primary
key.

combination of link and title for some feeds is too big for some feeds
and can not be used as primary key.

This pr is an attempt to use a generated hash field instead as part of
primary key

For now, this we will start populating a new field