### PR TITLE
Remove custom templating system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,6 @@ dependencies = [
  "log",
  "mockito",
  "nanohtml2text",
- "regex",
  "rss",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ nanohtml2text = "0.1"
 htmlescape = "0.3"
 isahc = "1"
 log = "0.4"
-regex = { version = "1", features = ["pattern"] }
 rss = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ####################################################################################################
 ## Builder
 ####################################################################################################
-FROM rustlang/rust:nightly-bullseye AS builder
+FROM rust:1.58.1-bullseye AS builder
 RUN apt update && apt install -y libssl-dev pkg-config libz-dev libcurl4 postgresql
 RUN update-ca-certificates
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,16 @@ It's available at [@el_monitorro_bot](https://t.me/el_monitorro_bot).
 - bot_item_link - url of the item
 - bot_item_description - description of the item
 - bot_date - publication date of the feed
-- bot_space - defines a space character
-- bot_new_line - defines a new line character
-Example: /set_template https://www.badykov.com/feed.xml bot_datebot_spacebot_item_namebot_new_linebot_item_description.
+Example: /set_template https://www.badykov.com/feed.xml {{bot_feed_name}}
+
+
+    {{bot_item_name}}
+
+
+    {{bot_date}}
+
+
+    {{bot_item_link}}
 
 /get_template url - get a template for the subscription
 

--- a/src/bot/commands/help.rs
+++ b/src/bot/commands/help.rs
@@ -20,9 +20,7 @@ static HELP: &str =
          - bot_item_link - url of the item\n\
          - bot_item_description - description of the item\n\
          - bot_date - publication date of the feed\n\
-         - bot_space - defines a space character\n\
-         - bot_new_line - defines a new line character\n\
-         Example: /set_template https://www.badykov.com/feed.xml bot_datebot_spacebot_item_namebot_new_linebot_item_description\n\n\
+         Example: /set_template https://www.badykov.com/feed.xml {{bot_feed_name}}\n\n\n{{bot_item_name}}\n\n\n{{bot_date}}\n\n\n{{bot_item_link}}\n\n\
          /get_template url - get the template for the subscription\n\n\
          /set_global_template template - set global template. This template will be used for all subscriptions. If the subscription has its own template, it will be used instead. See /set_template for available fields.\n\n\
          /get_global_template - get global template\n\n\

--- a/src/bot/commands/set_global_template.rs
+++ b/src/bot/commands/set_global_template.rs
@@ -1,6 +1,5 @@
 use super::Command;
 use super::Message;
-use super::Template;
 use crate::bot::telegram_client::Api;
 use crate::db::telegram;
 use diesel::r2d2::ConnectionManager;
@@ -31,18 +30,17 @@ impl SetGlobalTemplate {
             None => return "You don't have any subcriptions".to_string(),
         };
 
-        match self.parse_template_and_send_example(template) {
-            Ok((template, example)) => {
-                match telegram::set_global_template(db_connection, &chat, template) {
-                    Ok(_) => format!(
-                        "The global template was updated. Your messages will look like:\n\n{}",
-                        example
-                    ),
-                    Err(_) => "Failed to update the template".to_string(),
-                }
-            }
+        let example = match super::template_example(&template) {
+            Ok(example) => example,
+            Err(_) => return "The template is invalid".to_string(),
+        };
 
-            Err(error) => error,
+        match telegram::set_global_template(db_connection, &chat, template) {
+            Ok(_) => format!(
+                "The global template was updated. Your messages will look like:\n\n{}",
+                example
+            ),
+            Err(_) => "Failed to update the template".to_string(),
         }
     }
 
@@ -71,5 +69,3 @@ impl Command for SetGlobalTemplate {
         Self::command()
     }
 }
-
-impl Template for SetGlobalTemplate {}


### PR DESCRIPTION
- remove custom templating system
- now stable rust can be used because `regex` is not used anymore

resolves https://github.com/ayrat555/el_monitorro/issues/194