### PR TITLE
fix: not to look title in order to insert a new feed

### DIFF
--- a/src/db/feed_items.rs
+++ b/src/db/feed_items.rs
@@ -36,7 +36,7 @@ pub trait ContentHashable {
     fn content_field_names(&self, feed: &Feed) -> Vec<String> {
         feed.content_fields
             .clone()
-            .unwrap_or_else(|| vec!["link".to_string(), "title".to_string()])
+            .unwrap_or_else(|| vec!["link".to_string()])
     }
 }
 

--- a/src/db/feed_items.rs
+++ b/src/db/feed_items.rs
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn generates_content_hash_from_link_and_title_by_default() {
+    fn generates_content_hash_from_link_by_default() {
         let mut connection = db::establish_test_connection();
 
         connection.test_transaction::<_, Error, _>(|connection| {
@@ -253,7 +253,6 @@ mod tests {
 
             let mut content: String = "".to_string();
             content.push_str(&feed_item.link);
-            content.push_str(&feed_item.title);
 
             let expected_hash = calculate_hash(&content);
 


### PR DESCRIPTION
As requested of some users, the pr is to fix that el_monitorro sends an update when title is changed. This is an undesired behaviour.